### PR TITLE
Fix shifting on hover of TodoItem component

### DIFF
--- a/src/TodoItem.js
+++ b/src/TodoItem.js
@@ -21,7 +21,7 @@ function TodoItem({ task, isBenchmark, cancelFunc, cloneFunc, theme }) {
           statusToSymbol(task.status) :
           statusToSymbol(task.was)}</span>
       <span className={`${task.status === "cancelled" && "strike"}`}>{task.text}</span>
-      <div className="relative ml1 h-15">
+      <div className="relative ml1 h-15 w3">
         {cancelFunc && cloneFunc &&
         <>
       {task.status === "new" || task.status === "ready" ?


### PR DESCRIPTION
On hover of items long enough the cancel button will shift the contents. I made the empty element that holds the cancel button have the same width + 1 padding.


## before
[Screencast from 11-22-2023 01:54:05 PM.webm](https://github.com/avidrucker/pwa-autofocus-app/assets/77356082/0f5c068f-c265-4feb-920a-af4bae4008b2)

## after
[Screencast from 11-22-2023 01:53:07 PM.webm](https://github.com/avidrucker/pwa-autofocus-app/assets/77356082/91f74f93-2727-4b87-b652-a5d6a74357c6)
